### PR TITLE
 	Update some deprecated MDAnalysis calls

### DIFF
--- a/mdreader.py
+++ b/mdreader.py
@@ -651,7 +651,7 @@ class MDreader(MDAnalysis.Universe, argparse.ArgumentParser):
             elif type(coords) == types.IntType:
                 tjcdx_atgrps = [self.ndxgs[coords]]
             elif isinstance(coords, basestring):
-                tjcdx_atgrps = [self.selectAtoms(coords)]
+                tjcdx_atgrps = [self.select_atoms(coords)]
             else:
                 self._tseries._coords_istuple = True
                 try:
@@ -661,7 +661,7 @@ class MDreader(MDAnalysis.Universe, argparse.ArgumentParser):
                         elif type(atgrp) == MDAnalysis.core.AtomGroup.AtomGroup:
                             tjcdx_atgrps.append(atgrp)
                         else:
-                            tjcdx_atgrps.append(self.selectAtoms("%s" % atgrp))
+                            tjcdx_atgrps.append(self.select_atoms("%s" % atgrp))
                 except:
                     raise TypeError("Error parsing coordinate groups.\n%r" % sys.exc_info()[1])
 

--- a/mdreader.py
+++ b/mdreader.py
@@ -920,9 +920,9 @@ class MDreader(MDAnalysis.Universe, argparse.ArgumentParser):
                     else:
                         tmpstr += line
         else:
-            resnames = numpy.unique(self.atoms.resnames())
-            self._ndx_atlists = [_NamedAtlist(self.atoms.indices(), "System")]
-            self._ndx_atlists.extend([_NamedAtlist(self.selectAtoms("resname %s" % (rn,)).indices(), rn) for rn in resnames ])
+            resnames = numpy.unique(self.atoms.resnames)
+            self._ndx_atlists = [_NamedAtlist(self.atoms.indices, "System")]
+            self._ndx_atlists.extend([_NamedAtlist(self.select_atoms("resname %s" % (rn,)).indices, rn) for rn in resnames ])
         self._ndx_names = [ndx.ndx_name for ndx in self._ndx_atlists]
 
     def _ndx_prepare(self):


### PR DESCRIPTION
Update some calls to MDAnalysis to use the 0.11 API. This fix the oddities that caused #4.

This commit also fix the part of #3 related to a missing `-n` argument.
