### PR TITLE
Fix implicit relative import in __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-from mdreader import *
+from .mdreader import *


### PR DESCRIPTION
An implicit relative import in `__init__.py` were preventing MDreader to
get imported on python 3.

By the way, adding this single character allowed me to use MDreader on python 3.
